### PR TITLE
Bump ckeditor version.

### DIFF
--- a/ding_content.make
+++ b/ding_content.make
@@ -68,11 +68,11 @@ projects[workbench][version] = 1.1
 
 projects[wysiwyg][type] = module
 projects[wysiwyg][subdir] = contrib
-projects[wysiwyg][version] = 2.1
+projects[wysiwyg][version] = 2.2
 
 ; Libraries
 libraries[ckeditor][download][type] = get
-libraries[ckeditor][download][url] = http://download.cksource.com/CKEditor/CKEditor/CKEditor%203.6.2/ckeditor_3.6.2.zip
+libraries[ckeditor][download][url] = http://download.cksource.com/CKEditor/CKEditor/CKEditor%203.6.6.1/ckeditor_3.6.6.1.zip
 libraries[ckeditor][directory_name] = ckeditor
 libraries[ckeditor][destination] = libraries
 


### PR DESCRIPTION
3.6.2 doesn't work properly for IE 10. It isn't possible to make line breaks (hitting 'enter' doesn't make a new line).
