### PR TITLE
Bug #597. Added styles in CKeditor for aligning images on left and right

### DIFF
--- a/js/ding_content.editor_config.js
+++ b/js/ding_content.editor_config.js
@@ -84,4 +84,6 @@ CKEDITOR.stylesSet.add('default',[
   {name:'Condensed Table',element:'table',attributes:{'class': 'table-condensed'}},
   {name:'Borderless Table',element:'table',attributes:{'class': 'table-borderless'}},
   {name:'Striped  Table',element:'table',attributes:{'class': 'table-striped'}},
+  {name:'Image on Left',element:'img',attributes:{style:'padding: 5px; margin-right: 5px',border:'2',align:'left'}},
+  {name:'Image on Right',element:'img',attributes:{style:'padding: 5px; margin-left: 5px',border:'2',align:'right'}}
 ]);


### PR DESCRIPTION
Added options for aligning images in CKeditor.
http://platform.dandigbib.org/issues/597