### PR TITLE
Issue #767 by Inlead: Remove opening_hours dependency.

### DIFF
--- a/ding_content.info
+++ b/ding_content.info
@@ -20,7 +20,6 @@ dependencies[] = media_wysiwyg
 dependencies[] = media_youtube
 dependencies[] = menu
 dependencies[] = nodequeue
-dependencies[] = opening_hours
 dependencies[] = page_manager
 dependencies[] = panels
 dependencies[] = panels_node


### PR DESCRIPTION
http://platform.dandigbib.org/issues/767
